### PR TITLE
License change from GPLv3+ to LGPLv2.1+

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,15 @@
+Copyright (C) 2019-2023 Jose Tiago Macara Coutinho <coutinhotiago@gmail.com>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA

--- a/setup.py
+++ b/setup.py
@@ -21,10 +21,10 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
-        "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)"
+        "License :: OSI Approved :: GNU Lesser General Public License v2 or later (LGPLv2+)"
     ],
     description="Concurrency agnostic serialio API",
-    license="GPLv3+",
+    license="LGPL-2.1",
     install_requires=["pyserial>=3", "sockio>=0.15"],
     extras_require={
         "tango": ["pytango"]


### PR DESCRIPTION
Hi,

these are the necessary changes to switch licenses from GPLv3+ to LGPLv2.1+. Since you are the sole code contributor at this point in time, a license change is easily possible by accepting this PR.