### PR TITLE
Fix bug with sync concurrency mode

### DIFF
--- a/serialio/sio/__init__.py
+++ b/serialio/sio/__init__.py
@@ -11,5 +11,5 @@ def async_to_sync(class_or_func, *args, **kwargs):
     return DefaultEventLoop.proxy(serial, resolve_futures)
 
 
-def serial_for_url(url, *args, **kwargs):
+def serial_for_url(*args, **kwargs):
     return async_to_sync(aio_serial_for_url, *args, **kwargs)


### PR DESCRIPTION
Hi Tiago!

We realized that if we wanted to use the "sync" concurrency mode, we had an error like `Error: positional argument 'url' is missing`

The fix is very quick, if you want you can integrate it into your repo.

Best,

Jordi